### PR TITLE
[BE] Notification keep alive 수정 및 아이,부모 구독 엔드포인트변경, [FE] SSE emitter 메소드 수정

### DIFF
--- a/client/src/components/pages/child/ChildNotificationIcon.jsx
+++ b/client/src/components/pages/child/ChildNotificationIcon.jsx
@@ -44,7 +44,7 @@ export const ChildNotificationIcon = () => {
   };
   // SSE 연결
   const { eventSource, connectionError } = useSSE(
-    `${process.env.REACT_APP_BASE_URL}/notification/subscribe/${memberNo}`,
+    `${process.env.REACT_APP_BASE_URL}/notification/subscribe/child/${memberNo}`,
     (notification) => {
       try {
         if (

--- a/client/src/components/pages/landing/Landing1.jsx
+++ b/client/src/components/pages/landing/Landing1.jsx
@@ -5,12 +5,16 @@ export const Landing1 = () => {
   return (
     <Outer>
       <LeftContainer>
-        <img src="images/coin-1.svg" class="coin1" alt="Large Coin" />
-        <img src="images/coin-2.svg" class="coin2" alt="Small Left Coin" />
-        <img src="images/coin-3.svg" class="coin3" alt="Small Right Coin" />
-        <img src="images/stockCoin1.png" class="stockCoin1" alt="Bottom Coin" />
+        <img src="images/coin-1.svg" className="coin1" alt="Large Coin" />
+        <img src="images/coin-2.svg" className="coin2" alt="Small Left Coin" />
+        <img src="images/coin-3.svg" className="coin3" alt="Small Right Coin" />
+        <img
+          src="images/stockCoin1.png"
+          className="stockCoin1"
+          alt="Bottom Coin"
+        />
         {/* <img src="images/stockCoin2.png" class = "stockCoin2"/> */}
-        <img src="images/final_Donny.png" class="Donny" />
+        <img src="images/final_Donny.png" className="Donny" />
       </LeftContainer>
 
       <RightContainer>

--- a/client/src/components/pages/parent/ParentNotificationIcon.jsx
+++ b/client/src/components/pages/parent/ParentNotificationIcon.jsx
@@ -44,18 +44,35 @@ export const ParentNotificationIcon = () => {
 
   // SSE 연결
   const { eventSource, connectionError } = useSSE(
-    `${process.env.REACT_APP_BASE_URL}/notification/subscribe/${memberNo}`,
+    `${process.env.REACT_APP_BASE_URL}/notification/subscribe/parent/${memberNo}`,
     (notification) => {
+      // try {
+      //   if (
+      //     notification.notiNum !== -1 &&
+      //     notification.senderType === "child"
+      //   ) {
+      //     setNotifications((prev) => [notification, ...prev]); // 알림 목록 업데이트
+      //     setHasUnread(true); // 새 알림이 오면 미읽은 상태로 나타냄
+      //   }
+      // } catch (err) {
+      //   console.log("SSE 데이터 파싱 에러 : ", err);
+      // }
+      // 수정된 부분: SSE 이벤트 처리 개선
       try {
         if (
           notification.notiNum !== -1 &&
           notification.senderType === "child"
         ) {
-          setNotifications((prev) => [notification, ...prev]); // 알림 목록 업데이트
-          setHasUnread(true); // 새 알림이 오면 미읽은 상태로 나타냄
+          console.log("[SSE] 새로운 알림 수신:", notification);
+          setNotifications((prev) => {
+            const updated = [notification, ...prev];
+            console.log("[알림 업데이트] 업데이트된 알림 목록:", updated);
+            return updated;
+          });
+          setHasUnread(true); // 새 알림이 오면 미읽은 상태로 표시
         }
       } catch (err) {
-        console.log("SSE 데이터 파싱 에러 : ", err);
+        console.error("[SSE] 알림 데이터 처리 중 에러:", err); // 수정된 부분: 에러 로그 추가
       }
     }
   );
@@ -64,7 +81,7 @@ export const ParentNotificationIcon = () => {
   useEffect(() => {
     setListOpen(false);
     getNotifications();
-  }, []);
+  }, [memberNo, authorization]); // 수정된 부분: 의존성 배열에 추가
 
   // 알림 목록 변경시 로그출력해봄
   // useEffect(() => {

--- a/client/src/pages/child/MoneyPlanPage.jsx
+++ b/client/src/pages/child/MoneyPlanPage.jsx
@@ -64,7 +64,7 @@ const MoneyPlanPage = () => {
 
   const handleSend = () => {
     // 모달을 열기 전에 Context 값을 기반으로 동기화
-    console.log("모달 열기전 plan", plan);
+    // console.log("모달 열기전 plan", plan);
     setPlan([
       { label: "쇼핑", value: plan.shopping ?? 0 },
       { label: "교통", value: plan.transport ?? 0 },
@@ -73,12 +73,12 @@ const MoneyPlanPage = () => {
       { label: "기타", value: plan.others ?? 0 },
       { label: "저축", value: plan.saving ?? 0 },
     ]);
-    console.log("모달 연 후  plan", plan);
+    // console.log("모달 연 후  plan", plan);
     setModalOpen(true); // "부모님한테 보내기" 버튼 클릭 시 모달 열기
   };
   //console.log("db로 보낼 데이터", dataToSend);
-  console.log("MoneyPlanPage plan : ", plan);
-  console.log("MoneyPlanPage dataValues : ", plan);
+  // console.log("MoneyPlanPage plan : ", plan);
+  // console.log("MoneyPlanPage dataValues : ", plan);
 
   //나중에 로컬스토리지에서 데이터 받아오는거롤 수정해야함
   const token = authorization;
@@ -89,7 +89,7 @@ const MoneyPlanPage = () => {
     e.preventDefault(); // 폼 제출 시 새로고침 방지
     setIsLoading(true);
     setErrorMessage(null);
-    console.log("데이터 보내기 전의 plan", plan);
+    // console.log("데이터 보내기 전의 plan", plan);
     // 요청할 데이터를 변환하는 함수
     const transformPlanToRequestFormat = () => {
       return {
@@ -102,7 +102,7 @@ const MoneyPlanPage = () => {
       };
     };
     const requestBody = transformPlanToRequestFormat();
-    console.log("보낼 데이터를 다시 확인하기", requestBody);
+    // console.log("보낼 데이터를 다시 확인하기", requestBody);
     axios({
       method: "POST",
       url: `/children/plans?year=${currentYear}&month=${currentMonth}`,
@@ -113,12 +113,10 @@ const MoneyPlanPage = () => {
       },
     })
       .then((res) => {
-        // console.log("dataToSend=======", plan);
-        // console.log("axios res", res);
         setModalOpen(false); // 모달 닫기
         setIsLoading(false); // 로딩 상태 해제
 
-        console.log("authorization : ", authorization);
+        // console.log("authorization : ", authorization);
 
         setOverlayStatus(true); //수정 불가 창업데이트
         sendNotificationToParent(
@@ -131,8 +129,6 @@ const MoneyPlanPage = () => {
       })
       .catch((err) => {
         console.error("Error:", err.message); // 오류 메시지 출력
-        console.error("Error response:", err.response); // 서버 응답 (응답이 있을 경우)
-        console.error("Error stack:", err.stack); // 오류 스택 추적
         setIsLoading(false); // 로딩 상태 해제
         setErrorMessage("전송 중 오류가 발생했습니다. 다시 시도해주세요.");
         setOverlayStatus(false); //수정 불가 창업데이트

--- a/client/src/services/sseEmitter.js
+++ b/client/src/services/sseEmitter.js
@@ -12,7 +12,7 @@ export const useSSE = (url, onMessage) => {
     //   console.log("[SSE] 이미 연결되었습니다.");
     // }
     let sse; //
-    sse = new EventSource(url); // GET
+    sse = new EventSource(url); // GET, SSE 연결생성
     // GET /sse-endpoint HTTP/1.1
     // Host: example.com
     // Accept: text/event-stream
@@ -32,13 +32,12 @@ export const useSSE = (url, onMessage) => {
         if (event.data !== "ping") {
           // ping 이벤트는 무시하거나 연결 상태를 확인할때 사용됨
           // console.log("[SSE] keep-alive ping ");
-          console.log("[SSE] 받은 알림 데이터 : ", event.data);
-
+          console.log("[SSE] 받은 데이터:", event.data);
           try {
             const data = JSON.parse(event.data); // 데이터 파싱
             onMessage && onMessage(data); // 메세지 핸들러 호출
           } catch (err) {
-            console.error("에러 파싱 : ", err);
+            console.error("[SSE] 데이터 처리 에러:", err);
           }
         }
       };
@@ -60,7 +59,7 @@ export const useSSE = (url, onMessage) => {
 
       setEventSource(null);
     };
-  }, []);
+  }, [url]); // 수정된 부분: 의존성 배열에 `onMessage` 추가
 
   return { eventSource, connectionError };
 };

--- a/server/src/main/java/com/web/spring/controller/NotificationController.java
+++ b/server/src/main/java/com/web/spring/controller/NotificationController.java
@@ -32,11 +32,12 @@ public class NotificationController {
 	
 	// SSE 구독 설정
 	// 해당 아이디에 대한 SSEEmitter를 생성하고 반환한다(서버에서 데이터를 받게 된다)
-	@GetMapping(value = "/subscribe/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-	public SseEmitter subscribe(@PathVariable Long id, HttpServletResponse response) {
-		System.out.println("Emitter created and returned for ID: " + id);
+	@GetMapping(value = "/subscribe/{role}/{id}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+	public SseEmitter subscribe(@PathVariable String role, @PathVariable Long id, HttpServletResponse response) {
+		String uniqueId = role + "-" + id; // "parent-1", "child-1"
+		System.out.println("Emitter created and return uniqueId: " + uniqueId);
 		
-		return notificationService.subscribe(id, response);
+		return notificationService.subscribe(uniqueId, response);
 	}
 
 	// 알림 생성 및 전송 (parent ->  child)
@@ -63,9 +64,10 @@ public class NotificationController {
 	
 	// 해당 ID에 대한 데이터를 클라이언트에게 전송한다
 	@Transactional
-	@PostMapping("/send-data/{id}")
-	public void sendData(@PathVariable Long id, @RequestBody NotificationRequestDto notiRequestDto) {
-		notificationService.notify(id, notiRequestDto);
+	@PostMapping("/send-data/{role}/{id}")
+	public void sendData(@PathVariable String role, @PathVariable Long id, @RequestBody NotificationRequestDto notiRequestDto) {
+		String uniqueId = role + "-" + id; // "parent-1", "child-1"
+		notificationService.notify(uniqueId, notiRequestDto);
 	}
 	
 

--- a/server/src/main/java/com/web/spring/service/NotificationService.java
+++ b/server/src/main/java/com/web/spring/service/NotificationService.java
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,79 +45,122 @@ public class NotificationService {
     //타임아웃 설정 (1시간)
 	private static final Long DEFAULT_TIMEOUT = 60L * 1000 * 60;
 	// Emitter를 관리하기 위한 Map
-	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+//	private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+    
+    // Scheduler를 전역 멤버 변수로 선언 및 초기화
+    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 	
 	private static final Logger logger = LoggerFactory.getLogger(NotificationService.class);
 	
+	// 클라이언트가 구독을 호출하는 메소드(클라이언트 controller에서 구독페이지 엔드포인트를 생성하는데 사용된다.)
+    public SseEmitter subscribe(String uniqueId, final HttpServletResponse response) {
+        // 역할과 ID를 조합하여 고유 ID 생성
+    	System.out.println("구독 요청: " + uniqueId);
+
+        // 기존 Emitter가 있을 경우 삭제
+        if (emitters.containsKey(uniqueId)) {
+            emitters.remove(uniqueId);
+        }
+        // CORS 관련 헤더 설정
+        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
+        response.setHeader("Access-Control-Allow-Credentials", "true");
+        response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+        // SSE 관련 헤더 설정
+        response.setContentType("text/event-stream; charset=UTF-8");
+    	response.setCharacterEncoding("UTF-8");
+        
+        // Emitter를 생성하고 저장함
+        SseEmitter emitter = createEmitter(uniqueId); // Emitter 생성 및 추가
+        
+        // Emitter를 Map에 저장
+        emitters.put(uniqueId, emitter);
+        
+        // Keep-alive 설정
+        scheduleKeepAlive(uniqueId);
+        
+        // 현재 등록된 Emitters 출력
+        System.out.println("현재 등록된 Emitters: " + emitters.keySet());
+        
+        // 초기 더미 데이터를 전송하여 연결 상태 유지
+        sendInitialDummyNotification(uniqueId);
+        
+        System.out.println("현재 등록된 Emitters: " + emitters.keySet());
+    	
+    	return emitter;
+    }
+    
+    // Keep-alive 스케줄러 설정
+    private void scheduleKeepAlive(String uniqueId) {
+        scheduler.scheduleAtFixedRate(() -> {
+            SseEmitter activeEmitter = emitters.get(uniqueId); // 현재 Emitter 가져오기
+            if (activeEmitter != null) {
+                try {
+                    activeEmitter.send(SseEmitter.event().name("keep-alive").data("ping"));
+                } catch (IOException e) {
+                    System.out.println("[SSE] Keep-alive 실패, Emitter 제거: " + uniqueId);
+                    emitters.remove(uniqueId); // 실패 시 Emitter 제거
+                }
+            }
+        }, 0, 5, TimeUnit.SECONDS); // 5초 간격으로 Keep-alive 메시지 전송
+    }
+ // 초기 더미 데이터를 전송
+    private void sendInitialDummyNotification(String uniqueId) {
+        NotificationResponseDto dummyNotification = new NotificationResponseDto();
+        dummyNotification.setNotiNum(-1L); // -1로 설정하여 더미임을 구분 가능
+        dummyNotification.setMessage("연결확인용 더미 데이터");
+        dummyNotification.setCategory("dummy");
+        dummyNotification.setParentNum(-1L);
+        dummyNotification.setChildNum(-1L);
+        dummyNotification.setSenderType("dummy");
+
+        // 초기 더미 데이터를 전송하여 연결 상태 유지
+        sendSseNotification(uniqueId, dummyNotification);
+    }
+    
+	
+    // 수정: 고유 ID를 기반으로 관리하도록 변경
 	// Service에 SSE Emitter를 생성하고 타임아웃을 설정 해 준다.
-	private SseEmitter createEmitter(Long id) {
-		System.out.println("createEmitter id: " + id);
+	private SseEmitter createEmitter(String uniqueId) {
+		System.out.println("createEmitter uniqueId: " + uniqueId);
+		
 		// 기존 Emiiter가 존재하면 삭제(중복방지)
-		if(emitters.containsKey(id)) {
-			emitters.remove(id); 
+		if(emitters.containsKey(uniqueId)) {
+			emitters.remove(uniqueId); 
 		}
 		
 		// 새 Emitter 생성
 		SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
-		emitters.put(id, emitter);
+		emitters.put(uniqueId, emitter);
 		
 	    // Emitter 완료 시
 	    emitter.onCompletion(() -> {
-	        System.out.println("SSE Emitter 완료: " + id);
-	        emitters.remove(id);
+	        System.out.println("SSE Emitter 완료: " + uniqueId);
+	        emitters.remove(uniqueId);
 	    });
 
 	    // 타임아웃 처리
 	    emitter.onTimeout(() -> {
-	        System.out.println("SSE Emitter 타임아웃: " + id);
-	        emitters.remove(id);
+	        System.out.println("SSE Emitter 타임아웃: " + uniqueId);
+	        emitters.remove(uniqueId);
 	    });
 
 	    // 에러 처리
 	    emitter.onError((e) -> {
-	        System.out.println("SSE Emitter 에러 발생: " + id + ", 에러: " + e.getMessage());
-	        emitters.remove(id);
+	        System.out.println("SSE Emitter 에러 발생: " + uniqueId + ", 에러: " + e.getMessage());
+	        emitters.remove(uniqueId);
 	    });
 		
 		return emitter;
 	}
 	
-    // 알림 디비에 저장
-	@Transactional
-	public NotificationResponseDto sendEvent(NotificationRequestDto notiRequestDto) {
-	    Parent parent = parentRepository.findById(notiRequestDto.getParentNum())
-	            .orElseThrow(() -> new NoSuchElementException(PARENT_NOT_FOUND));
-	    Child child = childRepository.findById(notiRequestDto.getChildNum())
-	            .orElseThrow(() -> new NoSuchElementException(CHILD_NOT_FOUND));
-
-	    // 알림 저장
-	    Notification notification = new Notification(parent, child, notiRequestDto.getMessage(), notiRequestDto.getCategory(), notiRequestDto.getSenderType());
-	    Notification saveNotification = notificationRepository.save(notification);
-	    NotificationResponseDto notificationResponseDto = saveNotification.toNotification(saveNotification);
+	// 수정: 알림 전송 로직에서 고유 ID를 기반으로 대상 Emitter를 가져오도록 변경
+	// SSE를 통해 실제 실시간 알림을 전송하는 메서드  (https://velog.io/@black_han26/SSE-Server-Sent-Events)
+	private void sendSseNotification(String uniqueId, NotificationResponseDto notificationResponseDto) {	    
+	    SseEmitter emitter = emitters.get(uniqueId); // Emitter 가져오기
 	    
-//	    System.out.println("notificationResponseDto ==========" + notificationResponseDto);
-
-	    // 발신자에 따라 SSE 전송 대상 결정.. 알림 전송 메서드 호출
-	    if ("parent".equalsIgnoreCase(notiRequestDto.getSenderType())) {
-//	    	System.out.println("아이에게 알림 전송");
-	    	
-	    	// sender가 부모라면 아이에게 알림 전송
-	        sendSseNotification(child.getChildNum(), notificationResponseDto); 
-	    } else {	    	
-	    	// 아이가 부모에게 알림 전송
-//	    	System.out.println("부모에게 알림 전송");
-	        sendSseNotification(parent.getParentNum(), notificationResponseDto); 
-	    }
-	    
-	    return notificationResponseDto;
-		
-	}
-	
-	// (https://velog.io/@black_han26/SSE-Server-Sent-Events)
-	
-	// SSE를 통해 실제 실시간 알림을 전송하는 메서드 
-	private void sendSseNotification(Long id, NotificationResponseDto notificationResponseDto) {
-	    SseEmitter emitter = emitters.get(id); // Emitter 가져오기
+	    System.out.println("[SSE] 고유 ID: " + uniqueId);
+	    System.out.println("[SSE] Emitter 존재 여부: " + (emitter != null));
 	    System.out.println("emitter 확인 : " + emitter);
 	    
 	    if (emitter == null) return; // Emitter 없으면 종료
@@ -130,64 +174,36 @@ public class NotificationService {
 	                );	        
 	    } catch (IOException | IllegalStateException e) {
 	    	emitter.completeWithError(e);
-	        emitters.remove(id); // 오류 발생 시 Emitter 제거
+	        emitters.remove(uniqueId); // 오류 발생 시 Emitter 제거
 	    }
 	}
+    // 알림 디비에 저장
+	@Transactional
+	public NotificationResponseDto sendEvent(NotificationRequestDto notiRequestDto) {
+	    Parent parent = parentRepository.findById(notiRequestDto.getParentNum())
+	            .orElseThrow(() -> new NoSuchElementException(PARENT_NOT_FOUND));
+	    Child child = childRepository.findById(notiRequestDto.getChildNum())
+	            .orElseThrow(() -> new NoSuchElementException(CHILD_NOT_FOUND));
 
-    
-    // 클라이언트가 구독을 호출하는 메소드(클라이언트 controller에서 구독페이지 엔드포인트를 생성하는데 사용된다.)
-    public SseEmitter subscribe(Long id, final HttpServletResponse response) {
-        // 기존 Emitter가 있을 경우 삭제
-        if (emitters.containsKey(id)) {
-            emitters.remove(id);
+	    // 알림 저장
+	    Notification notification = new Notification(parent, child, notiRequestDto.getMessage(), notiRequestDto.getCategory(), notiRequestDto.getSenderType());
+	    Notification saveNotification = notificationRepository.save(notification);
+	    NotificationResponseDto notificationResponseDto = saveNotification.toNotification(saveNotification);
+
+        // 수정: 발신자에 따라 고유 ID를 생성하여 알림 전송
+        if ("parent".equalsIgnoreCase(notiRequestDto.getSenderType())) {
+            String childUniqueId = "child-" + notiRequestDto.getChildNum();
+            sendSseNotification(childUniqueId, notificationResponseDto); // 아이에게 알림 전송
+        } else {
+            String parentUniqueId = "parent-" + notiRequestDto.getParentNum();
+            sendSseNotification(parentUniqueId, notificationResponseDto); // 부모에게 알림 전송
         }
-        // CORS 관련 헤더 설정
-        response.setHeader("Access-Control-Allow-Origin", "http://localhost:3000");
-        response.setHeader("Access-Control-Allow-Credentials", "true");
-        response.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+	    return notificationResponseDto;
+	}
 
-        // SSE 관련 헤더 설정
-        response.setContentType("text/event-stream; charset=UTF-8");
-    	response.setCharacterEncoding("UTF-8");
-        
-        // id를 이용하여 클라이언트와 매핑되는 Emitter를 생성하고 저장함
-        SseEmitter emitter = createEmitter(id); // Emitter 생성 및 추가
-        emitters.put(id, emitter);
-        
-        // 클라이언트에게 주기적으로 빈 데이터를 보내 연결을 유지시킨다
-        Runnable keepAlive = () -> {
-            try {
-                emitter.send(SseEmitter.event().name("keep-alive").data("ping").reconnectTime(3000));
-            } catch (IOException e) {
-//                e.printStackTrace(); // production 환경에서는 보안상 slf4j나 logback 등을 사용
-            	logger.error("keep-aliv 메세지 전송실채, 클라이언트 연결 해제 처리. ", e);
-            	emitters.remove(id); // 연결 끊김 시 Emitter 제거(추가)
-            }
-        };
-        
-        // 5초마다 빈 메시지를 보내는 스케줄러 실행
-        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
-        scheduler.scheduleAtFixedRate(keepAlive, 0, 5, TimeUnit.SECONDS);
-    	
-    	// 초기 연결시 전송할 더미 데이터 생성
-    	// 클라이언트와의 초기 연결에서 아무 이벤트도 전송하지 않으면, 재연결 요청이나 연결 자체에서 오류가 발생할 수 있기 때문에
-    	// 첫 SSE 응답을 보낼시 더미 데이터를 넣어 오류를 방지한다.
-//    	System.out.println("더미 데이터 전송 전 emitters 확인: " + emitters);
-    	NotificationResponseDto dummyNotification  = new NotificationResponseDto();
-    	dummyNotification.setNotiNum(-1L); //-1로 설정하여 더미임을 구분 가능
-    	dummyNotification.setMessage("연결확인용 더미 데이터");
-    	dummyNotification.setCategory("dummy");
-    	dummyNotification.setParentNum(-1L);
-    	dummyNotification.setChildNum(-1L);
-    	dummyNotification.setSenderType("dummy");
-    	
-    	// 초기 더미 데이터를 전송하여 연결 상태 유지 
-    	sendSseNotification(id, dummyNotification);
-    	
-    	return emitter;
-    }
-    // 실제 알림 전송 메서드
-	public void notify(Long id, NotificationRequestDto notiRequestDto) {
+	// 실제 알림 전송 메서드
+	// 수정: 실제 알림 전송 메서드에서 고유 ID를 사용
+	public void notify(String uniqueId, NotificationRequestDto notiRequestDto) {
 		// 클라이언트에게 실제 알림데이터를 전송함
 	    // NotificationRequestDto를 NotificationResponseDto로 변환
 	    NotificationResponseDto notificationResponseDto = new NotificationResponseDto(
@@ -199,8 +215,7 @@ public class NotificationService {
 	        notiRequestDto.getSenderType(),
 	        notiRequestDto.getIsRead()
 	    );
-
-		sendSseNotification(id, notificationResponseDto);
+		sendSseNotification(uniqueId, notificationResponseDto);
 	}
     
     // 조회


### PR DESCRIPTION
[BE] 
Notification keep alive : 부모,아이 페이지 이동시 서버에 등록된 emitters에서 제거되는 현상 발생하였음
구독 엔드포인트변경 : 사용자 num으로 구독메소드 호출 시 중복되어 덮어씌워지는 현상 발생하였음